### PR TITLE
Use sb-debug:print-backtrace

### DIFF
--- a/dev/backtrace.lisp
+++ b/dev/backtrace.lisp
@@ -101,7 +101,7 @@ string. Otherwise, returns nil.
 	(sb-debug:*debug-print-level* nil)
 	#-:sbcl-debug-print-variable-alist
 	(sb-debug:*debug-print-length* nil))
-    (sb-debug:backtrace most-positive-fixnum stream)))
+    (sb-debug:print-backtrace :count most-positive-fixnum :stream stream)))
 
 #+clisp
 (defun print-backtrace-to-stream (stream)


### PR DESCRIPTION
Hi thanks for trivial-backtrace,

`sb-debug:backtrace` was deprecated on sbcl-1.2.15, `print-backtrace` should be used instead

As you can infer from the deprecation warning in _src/code/debug.lisp_, the optional arguments are now keyword arguments

``` lisp
(define-deprecated-function :early "1.2.15" backtrace (print-backtrace)
    (&optional (count *backtrace-frame-count*) (stream *debug-io*))
  (print-backtrace :count count :stream stream))
```
