### PR TITLE
Use best-effort mode for sb-debug:print-backtrace

### DIFF
--- a/dev/backtrace.lisp
+++ b/dev/backtrace.lisp
@@ -101,7 +101,7 @@ string. Otherwise, returns nil.
 	(sb-debug:*debug-print-level* nil)
 	#-:sbcl-debug-print-variable-alist
 	(sb-debug:*debug-print-length* nil))
-    (sb-debug:print-backtrace :count most-positive-fixnum :stream stream)))
+    (sb-debug:print-backtrace :count most-positive-fixnum :stream stream :emergency-best-effort t)))
 
 #+clisp
 (defun print-backtrace-to-stream (stream)


### PR DESCRIPTION
When :emergency-best-effort is set to t in sb-debug:print-backtrace,
that logic attempts to print as much of the backtrace as possible,
even when it encounters errors printing individual frames or objects.

That logic was added to SBCL in February 2014:
https://github.com/sbcl/sbcl/commit/fb51ab