### PR TITLE
Remove an extra second argument from PRINT-MAP-BACKTRACE

### DIFF
--- a/dev/map-backtrace.lisp
+++ b/dev/map-backtrace.lisp
@@ -47,9 +47,9 @@
   (impl-map-backtrace function))
 
 (defun print-map-backtrace (&optional (stream *debug-io*) &rest args)
-  (apply 'map-backtrace 
+  (apply 'map-backtrace
 	 (lambda (frame)
-	   (print-frame frame stream)) args))
+	   (print-frame frame stream))))
 
 (defun backtrace-string (&rest args)
   (with-output-to-string (stream)

--- a/test/tests.lisp
+++ b/test/tests.lisp
@@ -3,15 +3,31 @@
 (deftestsuite generates-backtrace (trivial-backtrace-test)
   ())
 
+(defmacro with-error-output ((condition-variable) &body body)
+  `(handler-case
+       (let ((x 1))
+	 (let ((y (- x (expt 1024 0))))
+	   (declare (optimize (safety 3)))
+	   (/ 2 y)))
+     (error (,condition-variable)
+       (setf output (progn ,@body)))))
+
 (addtest (generates-backtrace)
   test-1
   (let ((output nil))
-    (handler-case 
-	(let ((x 1))
-	  (let ((y (- x (expt 1024 0))))
-	    (declare (optimize (safety 3)))
-	    (/ 2 y)))
-      (error (c)
-	(setf output (print-backtrace c :output nil))))
+
+    (with-error-output (c)
+      (print-backtrace c :output nil))
+
     (ensure (stringp output))
     (ensure (plusp (length output)))))
+
+
+(addtest (backtrace-string)
+  test-2
+  (let ((output nil))
+
+    (with-error-output (c)
+      (backtrace-string c))
+
+    (ensure (stringp output))))


### PR DESCRIPTION
I'm not sure what this was doing there, but it makes it impossible to use `backtrace-string` (or probably anything else that might call `print-map-backtrace`.

I tried to add a test, but I can't figure out how to use lift, I always get an error.

Also, happy to undo the little refactor with the macro in the tests, it just seems like most tests will need to raise an error and then look at the output.