### PR TITLE
String output stream handling

### DIFF
--- a/dev/backtrace.lisp
+++ b/dev/backtrace.lisp
@@ -41,7 +41,7 @@ string. Otherwise, returns nil.
 	(stream (values output nil)))
     (unwind-protect
 	 (progn
-	   (format stream "~&Date/time: ~a" (date-time-string))
+	   (format stream "~&Date/time: ~a!~%" (date-time-string))
 	   (print-condition error stream)
 	   (terpri stream)
 	   (print-backtrace-to-stream stream)

--- a/dev/backtrace.lisp
+++ b/dev/backtrace.lisp
@@ -46,7 +46,7 @@ string. Otherwise, returns nil.
 	   (terpri stream)
 	   (print-backtrace-to-stream stream)
 	   (terpri stream)
-	   (when (typep stream 'string-stream)
+	   (when (null output)
 	     (get-output-stream-string stream)))
 	 ;; cleanup
 	 (when close?

--- a/test/tests.lisp
+++ b/test/tests.lisp
@@ -15,3 +15,17 @@
 	(setf output (print-backtrace c :output nil))))
     (ensure (stringp output))
     (ensure (plusp (length output)))))
+
+(addtest (generates-backtrace-to-string-stream)
+  test-2
+  (let ((output nil))
+    (handler-case 
+	(let ((x 1))
+	  (let ((y (- x (expt 1024 0))))
+	    (declare (optimize (safety 3)))
+	    (/ 2 y)))
+      (error (c)
+	(setf output (with-output-to-string (stream)
+		       (print-backtrace c :output nil)))))
+    (ensure (stringp output))
+    (ensure (plusp (length output)))))


### PR DESCRIPTION
Currently, trivial-backtrace doesn't being used with caller-supplied string-output-streams, because `print-backtrace` mistakes the supplied stream for the one it constructs if the caller passes `:output nil`:
```
(with-output-to-string (output)
  (trivial-backtrace:print-backtrace (make-instance 'condition) :output stream))
;=> ""
```

This PR fixes that by checking `(null output)` before retrieving the string-stream output, rather than `(typep stream 'string-stream)`. I added a test for that case, although I had some trouble getting lift to run it, so I'm not sure that the test is good.

I also included a second commit with a minor change to print a newline after the date/time string that gets printed with backtraces: as-is there's no space between the time and the beginning of the condition message, which is fairly hard to read. Feel free to discard that commit if you'd rather not have it.