### PR TITLE
Initial port to clasp

### DIFF
--- a/dev/backtrace.lisp
+++ b/dev/backtrace.lisp
@@ -113,6 +113,9 @@ string. Otherwise, returns nil.
 	(debug:*debug-print-length* nil))
     (debug:backtrace most-positive-fixnum stream)))
 
+#+clasp
+(defun print-backtrace-to-stream (stream)
+  (core:btcl :stream stream))
 
 ;; must be after the defun above or the docstring may be wiped out
 (setf (documentation 'print-backtrace-to-stream 'function)


### PR DESCRIPTION
Sample session:
```lisp
Starting cclasp-boehm-0.4.2-1033-g0dec030e2-cst ... loading image...
Top level in: #<PROCESS TOP-LEVEL @0x112def499>.
COMMON-LISP-USER> (ql:quickload :trivial-backtrace)
To load "trivial-backtrace":
  Load 1 ASDF system:
    trivial-backtrace
; Loading "trivial-backtrace"
......
(:TRIVIAL-BACKTRACE)
COMMON-LISP-USER> (ql:quickload :trivial-backtrace-test)
To load "trivial-backtrace-test":
  Load 1 ASDF system:
    trivial-backtrace-test
; Loading "trivial-backtrace-test"
..................................................
[package trivial-backtrace-test]...
(:TRIVIAL-BACKTRACE-TEST)
COMMON-LISP-USER> (let ((LIFT:*CURRENT-ASDF-SYSTEM-NAME*
       (asdf:find-system "trivial-backtrace")))
  (lift:run-tests :config :generic))

handle config: (:IF-DRIBBLE-EXISTS :SUPERSEDE)
handle config: (:DRIBBLE "lift.dribble")
handle config: (:PRINT-LENGTH 10)
handle config: (:PRINT-LEVEL 5)
handle config: (:PRINT-TEST-CASE-NAMES T)
handle config: (TRIVIAL-BACKTRACE-TEST)
Start: TRIVIAL-BACKTRACE-TEST
Start: GENERATES-BACKTRACE
  run: TEST-1                           Pass
handle config: (:REPORT-PROPERTY :TITLE "Trivial-Backtrace | Test results")
handle config: (:REPORT-PROPERTY :RELATIVE-TO TRIVIAL-BACKTRACE-TEST)
handle config: (:REPORT-PROPERTY :STYLE-SHEET "test-style.css")
handle config: (:REPORT-PROPERTY :IF-EXISTS :SUPERSEDE)
handle config: (:REPORT-PROPERTY :FORMAT :HTML)
handle config: (:REPORT-PROPERTY :FULL-PATHNAME "test-results/test-report.html")
handle config: (:REPORT-PROPERTY :UNIQUE-NAME T)
handle config: (:BUILD-REPORT)
#P"test-results/" 
Sending report (format :HTML) to /Users/karstenpoeck/lisp/compiler/clasp2/test-results-2019-06-06-1/index.html
handle config: (:REPORT-PROPERTY :UNIQUE-NAME T)
handle config: (:REPORT-PROPERTY :FORMAT :DESCRIBE)
handle config: (:REPORT-PROPERTY :FULL-PATHNAME "test-results/test-report.txt")
handle config: (:BUILD-REPORT)
Sending report (format :DESCRIBE) to test-results/test-report-2019-06-06-1.txt
handle config: (:REPORT-PROPERTY :FORMAT :SAVE)
handle config: (:REPORT-PROPERTY :FULL-PATHNAME "test-results/test-report.sav")
handle config: (:BUILD-REPORT)
Sending report (format :SAVE) to test-results/test-report-2019-06-06-1.sav
handle config: (:REPORT-PROPERTY :FORMAT :DESCRIBE)
handle config: (:REPORT-PROPERTY :FULL-PATHNAME *STANDARD-OUTPUT*)
handle config: (:BUILD-REPORT)
Sending report (format :DESCRIBE) to #<SYNONYM-STREAM +PROCESS-STANDARD-OUTPUT+>
Test Report for /Users/karstenpoeck/quicklisp/local-projects/fork-trivial-backtrace/lift-standard.config: 1 test run, all passed!
Lisp: NIL (cclasp-boehm-0.4.2-1033-g0dec030e2-cst)
On  : x86_64 Darwin Kernel Version 18.6.0: Thu Apr 25 23:16:27 PDT 2019; root:xnu-4903.261.4~2/RELEASE_X86_64 karsten-poecks-macbook-pro.local

#<Results for /Users/karstenpoeck/quicklisp/local-projects/fork-trivial-backtrace/lift-standard.config [1 Successful test]>
COMMON-LISP-USER> (handler-case 
    (let ((x 1))
      (let ((y (- x (expt 1024 0))))
        (declare (optimize (safety 3)))
        (/ 2 y)))
  (error (c)
    (trivial-backtrace::print-map-backtrace)))
<unknown>: CALL-WITH-BACKTRACE: 
 Arg(0) = #<FUNCTION LAMBDA>
<unknown>: IMPL-MAP-BACKTRACE: 
 Arg(0) = #<FUNCTION LAMBDA>
<unknown>: MAP-BACKTRACE: 
 Arg(0) = #<FUNCTION LAMBDA>
<unknown>: APPLY: 
 Arg(0) = TRIVIAL-BACKTRACE:MAP-BACKTRACE
 Arg(1) = #<FUNCTION LAMBDA>
 Arg(2) = NIL
<unknown>: PRINT-MAP-BACKTRACE: 
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: LAMBDA: 
<unknown>: _CCLASP-EVAL-WITH-ENV^CLASP-CLEAVIR^((T: 
 Arg(0) = (BLOCK #:G31336
  (LET ((#:G31337 NIL))
    (DECLARE (IGNORABLE #:G31337))
    (TAGBODY
      (HANDLER-BIND ..))))
 Arg(1) = NIL
<unknown>: SIMPLE-EVAL: 
 Arg(0) = (HANDLER-CASE
 (LET ((X 1))
   (LET ((Y (- X (EXPT 1024 0))))
     (DECLARE (OPTIMIZE (SAFETY 3)))
     (/ 2 Y))) ..)
 Arg(1) = NIL
 Arg(2) = #<STANDARD-GENERIC-FUNCTION CLASP-CLEAVIR::CCLASP-EVAL-WITH-ENV>
<unknown>: CCLASP-EVAL: 
 Arg(0) = (HANDLER-CASE
 (LET ((X 1))
   (LET ((Y (- X (EXPT 1024 0))))
     (DECLARE (OPTIMIZE (SAFETY 3)))
     (/ 2 Y))) ..)
 Arg(1) = NIL
<unknown>: LAMBDA: 
<unknown>: FUNWIND-PROTECT: 
 Arg(0) = #<FUNCTION LAMBDA>
 Arg(1) = #<FUNCTION LAMBDA>
<unknown>: _top.lsp-top130^522^TOP-COMPILE-FILE.90: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = CORE::*HANDLER-CLUSTERS*
 Arg(1) = (((SERIOUS-CONDITION . #<FUNCTION LAMBDA>)))
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = (((SERIOUS-CONDITION . #<FUNCTION LAMBDA>)))
<unknown>: LAMBDA: 
<unknown>: _top.lsp-top130^522^TOP-COMPILE-FILE.102: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = CORE::*RESTART-CLUSTERS*
 Arg(1) = ((#<RESTART.587808905>))
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = ((#<RESTART.587808905>))
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: CATCH-LAMBDA: 
<unknown>: CATCH-FUNCTION: 
 Arg(0) = ((NIL))
 Arg(1) = #<FUNCTION CC-GENERATE-AST::CATCH-LAMBDA>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: _top.lsp-top130^522^TOP-COMPILE-FILE.86: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = CORE::*TPL-LEVEL*
 Arg(1) = 0
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = 0
<unknown>: _top.lsp-top130^522^TOP-COMPILE-FILE.84: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = CORE::*QUIT-TAG*
 Arg(1) = ((NIL))
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = ((NIL))
<unknown>: _top.lsp-top130^522^TOP-COMPILE-FILE.82: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = CORE::*QUIT-TAGS*
 Arg(1) = ((NIL))
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = ((NIL))
<unknown>: _top.lsp-top130^522^TOP-COMPILE-FILE.80: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = CORE:*IHS-CURRENT*
 Arg(1) = 0
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = 0
<unknown>: _top.lsp-top130^522^TOP-COMPILE-FILE.78: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = CORE::*IHS-TOP*
 Arg(1) = 0
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = 0
<unknown>: _top.lsp-top130^522^TOP-COMPILE-FILE.76: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = CORE::*IHS-BASE*
 Arg(1) = 0
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = 0
<unknown>: _top.lsp-top130^522^TOP-COMPILE-FILE.74: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = CORE:*TPL-PROMPT-HOOK*
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: _top.lsp-top130^522^TOP-COMPILE-FILE.73: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = CORE::*TPL-COMMANDS*
 Arg(1) = (("Top level commands"
  ((:CF :COMPILE-FILE) CORE::TPL-COMPILE-COMMAND :STRING ":cf		Compile file"
   ":compile-file &string &rest files		[Top level command]~@
	:cf &string &rest files				[Abbreviation]~@
	~@ ..)))
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: TPL: 
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.26: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = CORE::*TPL-LEVEL*
 Arg(1) = -1
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = -1
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.24: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = ///
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.22: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = //
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.20: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = /
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.18: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = ***
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.16: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = **
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.14: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = *
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.12: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = -
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.10: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = +++
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.8: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = ++
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.6: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = +
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.4: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = *DEBUGGER-HOOK*
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: CATCH-LAMBDA: 
<unknown>: CATCH-FUNCTION: 
 Arg(0) = (NIL)
 Arg(1) = #<FUNCTION CC-GENERATE-AST::CATCH-LAMBDA>
<unknown>: _top.lsp-top130^378^TOP-COMPILE-FILE.3: 
 Arg(0) = NIL
 Arg(1) = NIL
<unknown>: _epilogue-cclasp.lisp-epilogue-cclasp460^1^TOP-COMPILE-FILE.1: 
<unknown>: CALL-WITH-VARIABLE-BOUND: 
 Arg(0) = CORE:*USE-INTERPRETER-FOR-EVAL*
 Arg(1) = NIL
 Arg(2) = #<FUNCTION CORE:TOP-LEVEL>
<unknown>: LAMBDA: 
 Arg(0) = NIL
<unknown>: _epilogue-cclasp.lisp-epilogue-cclasp460^1^TOP-COMPILE-FILE: 
````