### PR TITLE
Fix test-suite name

### DIFF
--- a/test/tests.lisp
+++ b/test/tests.lisp
@@ -16,8 +16,8 @@
     (ensure (stringp output))
     (ensure (plusp (length output)))))
 
-(addtest (generates-backtrace-to-string-stream)
-  test-2
+(addtest (generates-backtrace)
+  generates-backtrace-to-string-stream
   (let ((output nil))
     (handler-case 
 	(let ((x 1))


### PR DESCRIPTION
The first argument for the test is supposed to be the test suite.