### PR TITLE
Add file attributes for Genera

### DIFF
--- a/dev/backtrace.lisp
+++ b/dev/backtrace.lisp
@@ -1,3 +1,4 @@
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: TRIVIAL-BACKTRACE; Base: 10; -*-
 (in-package #:trivial-backtrace)
 
 (defun print-condition (condition stream)

--- a/dev/fallback.lisp
+++ b/dev/fallback.lisp
@@ -1,3 +1,4 @@
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: TRIVIAL-BACKTRACE; Base: 10; -*-
 (in-package #:trivial-backtrace)
 
 (eval-when (:compile-toplevel :load-toplevel :execute)

--- a/dev/map-backtrace.lisp
+++ b/dev/map-backtrace.lisp
@@ -1,3 +1,4 @@
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: TRIVIAL-BACKTRACE; Base: 10; -*-
 (in-package #:trivial-backtrace)
 
 (defstruct frame

--- a/dev/packages.lisp
+++ b/dev/packages.lisp
@@ -1,3 +1,4 @@
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: CL-USER; Base: 10; -*-
 (in-package #:common-lisp-user)
 
 (defpackage #:trivial-backtrace

--- a/dev/utilities.lisp
+++ b/dev/utilities.lisp
@@ -1,3 +1,4 @@
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: TRIVIAL-BACKTRACE; Base: 10; -*-
 (in-package #:trivial-backtrace)
 
 (defparameter *date-time-format* "%Y-%m-%d-%H:%M"

--- a/trivial-backtrace.asd
+++ b/trivial-backtrace.asd
@@ -1,3 +1,4 @@
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Base: 10; -*-
 (in-package #:common-lisp-user)
 
 (defpackage #:trivial-backtrace-system (:use #:asdf #:cl))


### PR DESCRIPTION
Genera doesn't handle (in-package ...) the way that most people expect, but instead uses the Package file attribute to determine which package to place definitions into. This is easily fixed by adding a comment line of the file:
```lisp
;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: <package-name> -*-
```
at the top of the file, with no change to the lisp code required.