### PR TITLE
`ccl::map-call-frames' requires a function of two arguments

### DIFF
--- a/dev/map-backtrace.lisp
+++ b/dev/map-backtrace.lisp
@@ -58,7 +58,8 @@
 
 #+ccl
 (defun impl-map-backtrace (func)
-  (ccl::map-call-frames (lambda (ptr) 
+  (ccl::map-call-frames (lambda (ptr ctx)
+			  (declare (ignore ctx))
 			  (multiple-value-bind (lfun pc)
 			      (ccl::cfp-lfun ptr)
 			    (let ((source-note (ccl:function-source-note lfun)))


### PR DESCRIPTION
Fixes this library for clozure cl