### PR TITLE
Fix clasp and ccl

### DIFF
--- a/dev/backtrace.lisp
+++ b/dev/backtrace.lisp
@@ -115,7 +115,7 @@ string. Otherwise, returns nil.
 
 #+clasp
 (defun print-backtrace-to-stream (stream)
-  (core:btcl :stream stream))
+  (CLASP-DEBUG:PRINT-BACKTRACE :stream stream))
 
 ;; must be after the defun above or the docstring may be wiped out
 (setf (documentation 'print-backtrace-to-stream 'function)

--- a/dev/backtrace.lisp
+++ b/dev/backtrace.lisp
@@ -115,7 +115,7 @@ string. Otherwise, returns nil.
 
 #+clasp
 (defun print-backtrace-to-stream (stream)
-  (CLASP-DEBUG:PRINT-BACKTRACE :stream stream))
+  (clasp-debug:print-backtrace :stream stream))
 
 ;; must be after the defun above or the docstring may be wiped out
 (setf (documentation 'print-backtrace-to-stream 'function)


### PR DESCRIPTION
* clasp has revamped the debugging interface, old code didn't work anymore
* ccl introduced another argument to the function passed in ccl::map-call-frames, see https://github.com/Clozure/ccl/blob/master/lib/backtrace.lisp#L255

Tests (unfortunately clasp does not compile lift anymore)
```lisp
COMMON-LISP-USER> (ql:quickload :trivial-backtrace)
To load "trivial-backtrace":
  Load 1 ASDF system:
    trivial-backtrace
; Loading "trivial-backtrace"
.
(:TRIVIAL-BACKTRACE)
COMMON-LISP-USER> (handler-case 
    (let ((x 1))
      (let ((y (- x (expt 1024 0))))
        (declare (optimize (safety 3))
                 (notinline /))
        (/ 2 y)))
  (error (c)
    (trivial-backtrace:print-backtrace c)))

Date/time: 2020-05-10-17:43!
An unhandled error condition has been signalled:
   Condition of type DIVISION-BY-ZERO was signaled.


   1: (CLASP-DEBUG:CALL-WITH-STACK #<FUNCTION CLASP-DEBUG::WITH-STACK-LAMBDA> :DELIMITED T)
   2: (CLASP-DEBUG:PRINT-BACKTRACE :STREAM #<TWO-WAY-STREAM >)
   3: (TRIVIAL-BACKTRACE:PRINT-BACKTRACE-TO-STREAM #<TWO-WAY-STREAM >)
   4: (TRIVIAL-BACKTRACE:PRINT-BACKTRACE #<DIVISION-BY-ZERO>)
   5: (LAMBDA ())
   6: ((METHOD CLASP-CLEAVIR::CCLASP-EVAL-WITH-ENV (T T)) (BLOCK #:G9534
  (LET ((#:G9535 NIL))
    (DECLARE (IGNORABLE #:G9535))
    (TAGBODY
      (RETURN-FROM #:G9534
        (HANDLER-BIND
         ((ERROR
           #'(LAMBDA (CORE::TEMP)
               (DECLARE (IGNORABLE CORE::TEMP))
               (SETQ #:G9535 CORE::TEMP)
               (GO #:G9536))))
         (LET ((X 1))
           (LET ((Y (- X (EXPT 1024 0))))
             (DECLARE (OPTIMIZE (SAFETY 3)) (NOTINLINE /))
             (/ 2 Y)))))
     #:G9536
      (RETURN-FROM #:G9534
        (LET ((C #:G9535))
          (TRIVIAL-BACKTRACE:PRINT-BACKTRACE C)))))) NIL)
  10: (CLASP-CLEAVIR::SIMPLE-EVAL (HANDLER-CASE
 (LET ((X 1))
   (LET ((Y (- X (EXPT 1024 0))))
     (DECLARE (OPTIMIZE (SAFETY 3)) (NOTINLINE /))
     (/ 2 Y)))
 (ERROR (C) (TRIVIAL-BACKTRACE:PRINT-BACKTRACE C))) NIL #<STANDARD-GENERIC-FUNCTION CLASP-CLEAVIR::CCLASP-EVAL-WITH-ENV>)
  11: (CLASP-CLEAVIR::CCLASP-EVAL (HANDLER-CASE
 (LET ((X 1))
   (LET ((Y (- X (EXPT 1024 0))))
     (DECLARE (OPTIMIZE (SAFETY 3)) (NOTINLINE /))
     (/ 2 Y)))
 (ERROR (C) (TRIVIAL-BACKTRACE:PRINT-BACKTRACE C))) NIL)
  14: (CORE::TPL :NOPRINT NIL)

NIL
COMMON-LISP-USER> (let ((output nil))
    (handler-case 
	(let ((x 1))
	  (let ((y (- x (expt 1024 0))))
	    (declare (optimize (safety 3))
                     (notinline /))
	    (/ 2 y)))
      (error (c)
	(setf output (trivial-backtrace:print-backtrace c :output nil))))
  (values output (stringp output)(plusp (length output))))

"Date/time: 2020-05-10-17:43!
An unhandled error condition has been signalled:
   Condition of type DIVISION-BY-ZERO was signaled.


   1: (CLASP-DEBUG:CALL-WITH-STACK #<FUNCTION CLASP-DEBUG::WITH-STACK-LAMBDA> :DELIMITED T)
   2: (CLASP-DEBUG:PRINT-BACKTRACE :STREAM #<STRING-OUTPUT-STREAM >)
   3: (TRIVIAL-BACKTRACE:PRINT-BACKTRACE-TO-STREAM #<STRING-OUTPUT-STREAM >)
   4: (TRIVIAL-BACKTRACE:PRINT-BACKTRACE #<DIVISION-BY-ZERO> :OUTPUT NIL)
   5: (LAMBDA ())
   6: ((METHOD CLASP-CLEAVIR::CCLASP-EVAL-WITH-ENV (T T)) (LET ((OUTPUT NIL))
  (HANDLER-CASE
   (LET ((X 1))
     (LET ((Y (- X (EXPT 1024 0))))
       (DECLARE (OPTIMIZE (SAFETY 3)) (NOTINLINE /))
       (/ 2 Y)))
   (ERROR (C) (SETF OUTPUT (TRIVIAL-BACKTRACE:PRINT-BACKTRACE C :OUTPUT NIL))))
  (VALUES OUTPUT (STRINGP OUTPUT) (PLUSP (LENGTH OUTPUT)))) NIL)
  10: (CLASP-CLEAVIR::SIMPLE-EVAL (LET ((OUTPUT NIL))
  (HANDLER-CASE
   (LET ((X 1))
     (LET ((Y (- X (EXPT 1024 0))))
       (DECLARE (OPTIMIZE (SAFETY 3)) (NOTINLINE /))
       (/ 2 Y)))
   (ERROR (C) (SETF OUTPUT (TRIVIAL-BACKTRACE:PRINT-BACKTRACE C :OUTPUT NIL))))
  (VALUES OUTPUT (STRINGP OUTPUT) (PLUSP (LENGTH OUTPUT)))) NIL #<STANDARD-GENERIC-FUNCTION CLASP-CLEAVIR::CCLASP-EVAL-WITH-ENV>)
  11: (CLASP-CLEAVIR::CCLASP-EVAL (LET ((OUTPUT NIL))
  (HANDLER-CASE
   (LET ((X 1))
     (LET ((Y (- X (EXPT 1024 0))))
       (DECLARE (OPTIMIZE (SAFETY 3)) (NOTINLINE /))
       (/ 2 Y)))
   (ERROR (C) (SETF OUTPUT (TRIVIAL-BACKTRACE:PRINT-BACKTRACE C :OUTPUT NIL))))
  (VALUES OUTPUT (STRINGP OUTPUT) (PLUSP (LENGTH OUTPUT)))) NIL)
  14: (CORE::TPL :NOPRINT NIL)

"
T
T
COMMON-LISP-USER> (handler-case 
    (let ((x 1))
      (let ((y (- x (expt 1024 0))))
        (declare (optimize (safety 3))
                 (notinline /))
        (/ 2 y)))
  (error ()
    (trivial-backtrace:backtrace-string)))

"<unknown>: #<FUNCTION CALL-WITH-STACK>: 
 Arg-0 = #<FUNCTION CLASP-DEBUG::WITH-STACK-LAMBDA>
/Users/karstenpoeck/quicklisp/local-projects/fork-trivial-backtrace/dev/map-backtrace.lisp:104: #<FUNCTION IMPL-MAP-BACKTRACE>: 
 Arg-0 = #<FUNCTION (LAMBDA (TRIVIAL-BACKTRACE::FRAME))>
/Users/karstenpoeck/quicklisp/local-projects/fork-trivial-backtrace/dev/map-backtrace.lisp:47: #<FUNCTION MAP-BACKTRACE>: 
 Arg-0 = #<FUNCTION (LAMBDA (TRIVIAL-BACKTRACE::FRAME))>
/Users/karstenpoeck/quicklisp/local-projects/fork-trivial-backtrace/dev/map-backtrace.lisp:50: #<FUNCTION PRINT-MAP-BACKTRACE>: 
 Arg-0 = #<STRING-OUTPUT-STREAM >
/Users/karstenpoeck/quicklisp/local-projects/fork-trivial-backtrace/dev/map-backtrace.lisp:56: #<FUNCTION BACKTRACE-STRING>: 
<unknown>: #<FUNCTION (LAMBDA NIL)>: 
<unknown>: #<FUNCTION (METHOD CCLASP-EVAL-WITH-ENV (T T))>: 
 Arg-0 = (BLOCK #:G10090
  (LET ((#:G10091 NIL))
    (DECLARE (IGNORABLE #:G10091))
    (TAGBODY
      (RETURN-FROM #:G10090 ..))))
 Arg-1 = NIL
<unknown>: #<FUNCTION SIMPLE-EVAL>: 
 Arg-0 = (HANDLER-CASE
 (LET ((X 1))
   (LET ((Y (- X (EXPT 1024 0))))
     (DECLARE (OPTIMIZE (SAFETY 3)) (NOTINLINE /))
     (/ 2 Y))) ..)
 Arg-1 = NIL
 Arg-2 = #<STANDARD-GENERIC-FUNCTION CLASP-CLEAVIR::CCLASP-EVAL-WITH-ENV>
<unknown>: #<FUNCTION CCLASP-EVAL>: 
 Arg-0 = (HANDLER-CASE
 (LET ((X 1))
   (LET ((Y (- X (EXPT 1024 0))))
     (DECLARE (OPTIMIZE (SAFETY 3)) (NOTINLINE /))
     (/ 2 Y))) ..)
 Arg-1 = NIL
<unknown>: #<FUNCTION TPL>: 
 Arg-0 = :NOPRINT
 Arg-1 = NIL
````
ccl
```lisp
? (handler-case 
    (let ((x 1))
      (let ((y (- x (expt 1024 0))))
        (declare (optimize (safety 3))
                 (notinline /))
        (/ 2 y)))
  (error (c)
    (trivial-backtrace:print-backtrace c)))
Date/time: 2020-05-10-17:46!
An unhandled error condition has been signalled: DIVISION-BY-ZERO detected
performing / on (2 0)


 (1219868) : 0 (PRINT-CALL-HISTORY :CONTEXT NIL :PROCESS NIL :ORIGIN NIL :DETAILED-P NIL :COUNT 1152921504606846975 :START-FRAME-NUMBER 0 :STREAM #<SYNONYM-STREAM to *TERMINAL-IO* #x3020004775CD> :PRINT-LEVEL 2 :PRINT-LENGTH 5 :PRINT-STRING-LENGTH :DEFAULT :SHOW-INTERNAL-FRAMES NIL :FORMAT :TRADITIONAL) 957
 (1219A00) : 1 (PRINT-BACKTRACE-TO-STREAM #<SYNONYM-STREAM to *TERMINAL-IO* #x3020004775CD>) 85
 (1219A30) : 2 (PRINT-BACKTRACE #<DIVISION-BY-ZERO #x302000C6A28D> :OUTPUT #<SYNONYM-STREAM to *TERMINAL-IO* #x3020004775CD> :IF-EXISTS :APPEND :VERBOSE NIL) 845
 (1219AB8) : 3 (TOPLEVEL-EVAL (HANDLER-CASE (LET # #) (ERROR # #)) NIL) 789
 (1219B30) : 4 (READ-LOOP :INPUT-STREAM #<SYNONYM-STREAM to *TERMINAL-IO* #x3020004777AD> :OUTPUT-STREAM #<SYNONYM-STREAM to *TERMINAL-IO* #x30200047764D> :BREAK-LEVEL 0 :PROMPT-FUNCTION #<Compiled-function (:INTERNAL CCL::READ-LOOP) (Non-Global)  #x30000058872F>) 2341
 (1219D78) : 5 (RUN-READ-LOOP :BREAK-LEVEL 0) 157
 (1219DA0) : 6 (TOPLEVEL-LOOP) 93
 (1219DB0) : 7 (FUNCALL #'#<(:INTERNAL (TOPLEVEL-FUNCTION (CCL::LISP-DEVELOPMENT-SYSTEM T)))>) 109
 (1219DD0) : 8 (FUNCALL #'#<(:INTERNAL CCL::MAKE-MCL-LISTENER-PROCESS)>) 661
 (1219E68) : 9 (RUN-PROCESS-INITIAL-FORM #<TTY-LISTENER listener(1) [Active] #x3020004764FD> (#<COMPILED-LEXICAL-CLOSURE # #x30200047602F>)) 669
 (1219EF0) : 10 (FUNCALL #'#<(:INTERNAL (CCL::%PROCESS-PRESET-INTERNAL (PROCESS)))> #<TTY-LISTENER listener(1) [Active] #x3020004764FD> (#<COMPILED-LEXICAL-CLOSURE # #x30200047602F>)) 581
 (1219F98) : 11 (FUNCALL #'#<(:INTERNAL CCL::THREAD-MAKE-STARTUP-FUNCTION)>) 277
NIL
? (handler-case 
    (let ((x 1))
      (let ((y (- x (expt 1024 0))))
        (declare (optimize (safety 3))
                 (notinline /))
        (/ 2 y)))
  (error ()
    (trivial-backtrace:backtrace-string)))
"/Users/karstenpoeck/quicklisp/local-projects/fork-trivial-backtrace/dev/map-backtrace.lisp:f1333: BACKTRACE-STRING: 
 ARGS = NIL
<unknown>:f0: NIL: 
/Users/karstenpoeck/lisp/compiler/ccl-git-karsten/level-1/l1-readloop-lds.lisp:f17815: TOPLEVEL-EVAL: 
 FORM = (HANDLER-CASE (LET ((X 1))
                (LET ((Y (- X (EXPT 1024 0))))
                  (DECLARE (OPTIMIZE (SAFETY 3)) (NOTINLINE /))
                  (/ 2 Y)))
              (ERROR NIL (TRIVIAL-BACKTRACE:BACKTRACE-STRING)))
 ENV = NIL
/Users/karstenpoeck/lisp/compiler/ccl-git-karsten/level-1/l1-readloop-lds.lisp:f12874: READ-LOOP: 
 INPUT-STREAM = #<SYNONYM-STREAM to *TERMINAL-IO* #x3020004777AD>
 OUTPUT-STREAM = #<SYNONYM-STREAM to *TERMINAL-IO* #x30200047764D>
 BREAK-LEVEL = 0
 PROMPT-FUNCTION = #<Compiled-function (:INTERNAL CCL::READ-LOOP) (Non-Global)  #x30000058872F>
/Users/karstenpoeck/lisp/compiler/ccl-git-karsten/level-1/l1-readloop-lds.lisp:f740: RUN-READ-LOOP: 
 ARGS = (:BREAK-LEVEL 0)
/Users/karstenpoeck/lisp/compiler/ccl-git-karsten/level-1/l1-readloop-lds.lisp:f846: TOPLEVEL-LOOP: 
/Users/karstenpoeck/lisp/compiler/ccl-git-karsten/level-1/l1-application.lisp:f10399: (INTERNAL (TOPLEVEL-FUNCTION (LISP-DEVELOPMENT-SYSTEM T))): 
/Users/karstenpoeck/lisp/compiler/ccl-git-karsten/level-1/l1-boot-lds.lisp:f4118: (INTERNAL MAKE-MCL-LISTENER-PROCESS): 
/Users/karstenpoeck/lisp/compiler/ccl-git-karsten/level-1/l1-processes.lisp:f12689: RUN-PROCESS-INITIAL-FORM: 
 PROCESS = #<TTY-LISTENER listener(1) [Active] #x3020004764FD>
 INITIAL-FORM = (#<COMPILED-LEXICAL-CLOSURE (:INTERNAL
                             CCL::MAKE-MCL-LISTENER-PROCESS) #x30200047602F>)
/Users/karstenpoeck/lisp/compiler/ccl-git-karsten/level-1/l1-processes.lisp:f12296: (INTERNAL (%PROCESS-PRESET-INTERNAL (PROCESS))): 
 PROCESS = #<TTY-LISTENER listener(1) [Active] #x3020004764FD>
 INITIAL-FORM = (#<COMPILED-LEXICAL-CLOSURE (:INTERNAL
                             CCL::MAKE-MCL-LISTENER-PROCESS) #x30200047602F>)
/Users/karstenpoeck/lisp/compiler/ccl-git-karsten/level-1/l1-lisp-threads.lisp:f5604: (INTERNAL THREAD-MAKE-STARTUP-FUNCTION): 
"
````