### PR TITLE
Fix map-backtrace on SBCL inside of condition handlers

### DIFF
--- a/dev/map-backtrace.lisp
+++ b/dev/map-backtrace.lisp
@@ -73,7 +73,10 @@
 
 #+sbcl
 (defun impl-map-backtrace (func)
-  (loop for f = (or sb-debug:*stack-top-hint* (sb-di:top-frame)) then (sb-di:frame-down f)
+  (loop for f = (or (and (typep sb-debug:*stack-top-hint* 'sb-di:frame)
+                         sb-debug:*stack-top-hint*)
+                    (sb-di:top-frame))
+          then (sb-di:frame-down f)
 	while f
 	do (funcall func 
 		    (make-frame :func 


### PR DESCRIPTION
Checks if sb-debug:*stack-top-hint* is actually a sbcl stack frame before using it.

Fixes #11 